### PR TITLE
Improve anisette parsing

### DIFF
--- a/request_reports.py
+++ b/request_reports.py
@@ -45,8 +45,8 @@ def getOTPHeaders():
     objc.loadBundleFunctions(AOSKitBundle, globals(), [("retrieveOTPHeadersForDSID", '')])
     util = NSClassFromString('AOSUtilities')
 
-    anisette = str(util.retrieveOTPHeadersForDSID_("-2")).split('"')
-    return anisette[7], anisette[3]
+    anisette = str(util.retrieveOTPHeadersForDSID_("-2")).replace('"', ' ').replace(';', ' ').split()
+    return anisette[6], anisette[3]
 
 def getCurrentTimes():
     import datetime, time


### PR DESCRIPTION
Sometimes the X-Apple-MD-M data field comes without the quotes, which breaks the script. This should make the parsing more robust.

Example:
```
{
    "X-Apple-MD" = "XXX...XXX";
    "X-Apple-MD-M" = XXX...XXX;
}
```