### PR TITLE
Simplify usage when a tag cycles through many keys

### DIFF
--- a/generate_keys.py
+++ b/generate_keys.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 import sys,base64,hashlib,random
 from p224 import scalar_mult,curve
+import argparse
 
 def int_to_bytes(n, length, endianess='big'):
     h = '%x' % n
@@ -13,11 +14,20 @@ def sha256(data):
     return digest.digest()
 
 
-nkeys = 1
-if len(sys.argv) == 2 and sys.argv[1].isdigit():
-    nkeys = int(sys.argv[1])
 
-for i in range(nkeys):
+parser = argparse.ArgumentParser()
+parser.add_argument('-k','--keys', help='number of keys to generate', type=int, default=1)
+parser.add_argument('-n','--name', help='name (prefix) of the keyfiles')
+parser.add_argument('-y','--yaml', help='yaml file where to write the list of generated keys')
+parser.add_argument('-v','--verbose', help='print keys as they are generated', action="store_true")
+args=parser.parse_args()
+
+if args.yaml is not None:
+  yaml=open(args.yaml+'.yaml','w')
+  yaml.write('  keys:\n')
+
+i=1
+while i<=args.keys:
     priv = random.getrandbits(224)
     adv,_ = scalar_mult(priv, curve.g)
 
@@ -28,15 +38,22 @@ for i in range(nkeys):
     adv_b64 = base64.b64encode(adv_bytes).decode("ascii")
     s256_b64 = base64.b64encode(sha256(adv_bytes)).decode("ascii")
 
-    print('%d)' % (i+1))
-    print('Private key: %s' % priv_b64)
-    print('Advertisement key: %s' % adv_b64)
-    print('Hashed adv key: %s' % s256_b64)
+    if args.verbose:
+      print('%d)' % (i))
+      print('Private key: %s' % priv_b64)
+      print('Advertisement key: %s' % adv_b64)
+      print('Hashed adv key: %s' % s256_b64)
     if '/' in s256_b64[:7]:
         print('no key file written, there was a / in the b64 of the hashed pubkey :(')
     else:
-        with open('%s.keys' % s256_b64[:7], 'w') as f:
+        if args.name:
+          fname = '%s_%d.keys' % (args.name, i)
+        else:
+          fname = '%s.keys' % s256_b64[:7]
+        with open(fname, 'w') as f:
             f.write('Private key: %s\n' % priv_b64)
             f.write('Advertisement key: %s\n' % adv_b64)
             f.write('Hashed adv key: %s\n' % s256_b64)
-
+        i = i +1
+        if args.yaml is not None:
+          yaml.write('    - "%s"\n' % adv_b64)


### PR DESCRIPTION
I modified generate_keys.py so that you can specify a prefix to use as a filename and a yaml file where to store the generated keys.
I the same way I modified request_reports to only use key files with a specific prefix.
In that case, the part after the prefix is considered as a subkey, included in the json.
I also made some more modification to request_reports to filter the reports based on the timestamp (apple's servers send all the reports), to sort them by timestamp (even if there are several keys it's the same tag, so it's more useful this way).
I added an isotimestamp in the json as well as a google maps url.
And the status byte :wink: 